### PR TITLE
Update admin report charts to use 'date' key instead of 'month' for X…

### DIFF
--- a/checkafe-admin/components/admin/admin-shop-report-chart.tsx
+++ b/checkafe-admin/components/admin/admin-shop-report-chart.tsx
@@ -41,7 +41,7 @@ export default function AdminShopReportChart({ data, loading }: ShopReportChartP
       <LineChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis 
-          dataKey="month" 
+          dataKey="date" 
           stroke="#888888" 
           fontSize={12}
           tickFormatter={(value) => {

--- a/checkafe-admin/components/admin/admin-user-report-chart.tsx
+++ b/checkafe-admin/components/admin/admin-user-report-chart.tsx
@@ -41,7 +41,7 @@ export default function AdminUserReportChart({ data, loading }: UserReportChartP
       <LineChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis 
-          dataKey="month" 
+          dataKey="date" 
           stroke="#888888" 
           fontSize={12}
           tickFormatter={(value) => {


### PR DESCRIPTION
…Axis dataKey, ensuring consistency across chart components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated charts to use "date" instead of "month" for x-axis values in shop and user report charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->